### PR TITLE
added react-router

### DIFF
--- a/app/controllers/sample_controller.rb
+++ b/app/controllers/sample_controller.rb
@@ -1,4 +1,6 @@
 class SampleController < ApplicationController
+  layout "hello_world"
+
   def index
   end
 end

--- a/app/javascript/bundles/HelloWorld/components/HelloWorld.jsx
+++ b/app/javascript/bundles/HelloWorld/components/HelloWorld.jsx
@@ -1,5 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
+import {Link} from 'react-router-dom'
 
 export default class HelloWorld extends React.Component {
   static propTypes = {
@@ -27,6 +28,7 @@ export default class HelloWorld extends React.Component {
         <h3>
           Hello, {this.state.name}!
         </h3>
+        <p><Link to={"/"}>sampleへ</Link></p>
         <hr />
         <form >
           <label htmlFor="name">

--- a/app/javascript/bundles/HelloWorld/containers/Sample.js
+++ b/app/javascript/bundles/HelloWorld/containers/Sample.js
@@ -1,0 +1,21 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+import {Link} from 'react-router-dom'
+
+export default class Sample extends React.Component {
+  /**
+   * @param props - Comes from your rails view.
+   */
+  constructor(props) {
+    super(props);
+  }
+
+  render() {
+    return (
+      <div>
+        <h3>sample</h3>
+        <p><Link to={"/hello_world"}>hello_worldへ</Link></p>
+      </div>
+    );
+  }
+}

--- a/app/javascript/bundles/HelloWorld/router/index.js
+++ b/app/javascript/bundles/HelloWorld/router/index.js
@@ -1,0 +1,28 @@
+import React from "react";
+import { renderToString } from 'react-dom/server'
+import { BrowserRouter, StaticRouter } from 'react-router-dom'
+
+
+const client = (props) => {
+  return (
+    <BrowserRouter>
+      {props.children}
+    </BrowserRouter>
+  )
+}
+
+const server = (props) => {
+  return (
+    renderToString(
+      <StaticRouter location={props.path} context={{}}>
+        {props.children}
+      </StaticRouter>
+    )
+  )
+}
+
+const Router = (props) => {
+  return typeof window !== 'undefined' ? client(props) : server(props)
+}
+
+export default Router

--- a/app/javascript/bundles/HelloWorld/startup/HelloWorldApp.jsx
+++ b/app/javascript/bundles/HelloWorld/startup/HelloWorldApp.jsx
@@ -1,15 +1,18 @@
 import React from 'react';
 import { Provider } from 'react-redux';
 
-import configureStore from '../store/helloWorldStore';
-import HelloWorldContainer from '../containers/HelloWorldContainer';
+import configureStore from '../store/helloWorldStore'
+import Router from '../router/index'
+import routes from './routes'
 
 // See documentation for https://github.com/reactjs/react-redux.
 // This is how you get props from the Rails view into the redux store.
 // This code here binds your smart component to the redux store.
 const HelloWorldApp = (props) => (
   <Provider store={configureStore(props)}>
-    <HelloWorldContainer />
+    <Router>
+      {routes}
+    </Router>
   </Provider>
 );
 

--- a/app/javascript/bundles/HelloWorld/startup/routes.js
+++ b/app/javascript/bundles/HelloWorld/startup/routes.js
@@ -1,0 +1,13 @@
+import React from 'react'
+import {Route, Switch} from 'react-router-dom'
+
+import HelloWorldApp from './HelloWorldApp'
+import Sample from '../containers/Sample'
+import HelloWorldContainer from '../containers/HelloWorldContainer'
+
+export default (
+  <Switch>
+    <Route exact path="/" component={Sample}/>
+    <Route exact path="/hello_world" component={HelloWorldContainer}/>
+  </Switch>
+)

--- a/app/views/hello_world/index.html.erb
+++ b/app/views/hello_world/index.html.erb
@@ -1,2 +1,2 @@
 <h1>Hello World</h1>
-<%= react_component("HelloWorldApp", props: @hello_world_props, prerender: false) %>
+<%= react_component("HelloWorldApp", props: @hello_world_props, prerender: true) %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -5,7 +5,7 @@
     <%= csrf_meta_tags %>
 
     <%= stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track': 'reload' %>
-    <%= javascript_pack_tag 'hello_react' %>
+    <%= javascript_pack_tag 'hello-world-bundle' %>
   </head>
 
   <body>

--- a/app/views/layouts/hello_world.html.erb
+++ b/app/views/layouts/hello_world.html.erb
@@ -3,10 +3,10 @@
   <head>
     <title>ReactOnRailsWithWebpacker</title>
     <%= csrf_meta_tags %>
-    <%= javascript_pack_tag 'hello-world-bundle' %>
   </head>
 
   <body>
     <%= yield %>
+    <%= javascript_pack_tag 'hello-world-bundle' %>
   </body>
 </html>

--- a/app/views/sample/index.html.erb
+++ b/app/views/sample/index.html.erb
@@ -1,2 +1,3 @@
 <h1>Sample#index</h1>
-<p>Find me in app/views/sample/index.html.erb</p>
+<h2>hogehoge</h2>
+<%= react_component("HelloWorldApp", prerender: true) %>

--- a/package.json
+++ b/package.json
@@ -9,6 +9,8 @@
     "react-dom": "^16.2.0",
     "react-on-rails": "^10.1.1",
     "react-redux": "^5.0.7",
+    "react-router": "^4.2.0",
+    "react-router-dom": "^4.2.2",
     "redux": "^3.7.2"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2662,6 +2662,16 @@ hawk@~6.0.2:
     hoek "4.x.x"
     sntp "2.x.x"
 
+history@^4.7.2:
+  version "4.7.2"
+  resolved "https://registry.yarnpkg.com/history/-/history-4.7.2.tgz#22b5c7f31633c5b8021c7f4a8a954ac139ee8d5b"
+  dependencies:
+    invariant "^2.2.1"
+    loose-envify "^1.2.0"
+    resolve-pathname "^2.2.0"
+    value-equal "^0.4.0"
+    warning "^3.0.0"
+
 hmac-drbg@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/hmac-drbg/-/hmac-drbg-1.0.1.tgz#d2745701025a6c775a6c545793ed502fc0c649a1"
@@ -2678,7 +2688,7 @@ hoek@4.x.x:
   version "4.2.1"
   resolved "https://registry.yarnpkg.com/hoek/-/hoek-4.2.1.tgz#9634502aa12c445dd5a7c5734b572bb8738aacbb"
 
-hoist-non-react-statics@^2.5.0:
+hoist-non-react-statics@^2.3.0, hoist-non-react-statics@^2.5.0:
   version "2.5.0"
   resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-2.5.0.tgz#d2ca2dfc19c5a91c5a6615ce8e564ef0347e2a40"
 
@@ -2843,7 +2853,7 @@ interpret@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/interpret/-/interpret-1.1.0.tgz#7ed1b1410c6a0e0f78cf95d3b8440c63f78b8614"
 
-invariant@^2.0.0, invariant@^2.2.2:
+invariant@^2.0.0, invariant@^2.2.1, invariant@^2.2.2:
   version "2.2.2"
   resolved "https://registry.yarnpkg.com/invariant/-/invariant-2.2.2.tgz#9e1f56ac0acdb6bf303306f338be3b204ae60360"
   dependencies:
@@ -3104,6 +3114,10 @@ is-utf8@^0.2.0:
 is-wsl@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-wsl/-/is-wsl-1.1.0.tgz#1f16e4aa22b04d1336b66188a66af3c600c3a66d"
+
+isarray@0.0.1:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/isarray/-/isarray-0.0.1.tgz#8a18acfca9a8f4177e09abfc6038939b05d1eedf"
 
 isarray@1.0.0, isarray@^1.0.0, isarray@~1.0.0:
   version "1.0.0"
@@ -3396,7 +3410,7 @@ longest@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/longest/-/longest-1.0.1.tgz#30a0b2da38f73770e8294a0d22e6625ed77d0097"
 
-loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.3.1:
+loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.2.0, loose-envify@^1.3.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.3.1.tgz#d1a8ad33fa9ce0e713d65fdd0ac8b748d478c848"
   dependencies:
@@ -4043,6 +4057,12 @@ path-to-regexp@0.1.7:
   version "0.1.7"
   resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-0.1.7.tgz#df604178005f522f15eb4490e7247a1bfaa67f8c"
 
+path-to-regexp@^1.7.0:
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-1.7.0.tgz#59fde0f435badacba103a84e9d3bc64e96b9937d"
+  dependencies:
+    isarray "0.0.1"
+
 path-type@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/path-type/-/path-type-1.1.0.tgz#59c44f7ee491da704da415da5a4070ba4f8fe441"
@@ -4663,7 +4683,7 @@ promise@^7.1.1:
   dependencies:
     asap "~2.0.3"
 
-prop-types@^15.6.0:
+prop-types@^15.5.4, prop-types@^15.6.0:
   version "15.6.0"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.6.0.tgz#ceaf083022fc46b4a35f69e13ef75aed0d639856"
   dependencies:
@@ -4823,6 +4843,29 @@ react-redux@^5.0.7:
     lodash-es "^4.17.5"
     loose-envify "^1.1.0"
     prop-types "^15.6.0"
+
+react-router-dom@^4.2.2:
+  version "4.2.2"
+  resolved "https://registry.yarnpkg.com/react-router-dom/-/react-router-dom-4.2.2.tgz#c8a81df3adc58bba8a76782e946cbd4eae649b8d"
+  dependencies:
+    history "^4.7.2"
+    invariant "^2.2.2"
+    loose-envify "^1.3.1"
+    prop-types "^15.5.4"
+    react-router "^4.2.0"
+    warning "^3.0.0"
+
+react-router@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/react-router/-/react-router-4.2.0.tgz#61f7b3e3770daeb24062dae3eedef1b054155986"
+  dependencies:
+    history "^4.7.2"
+    hoist-non-react-statics "^2.3.0"
+    invariant "^2.2.2"
+    loose-envify "^1.3.1"
+    path-to-regexp "^1.7.0"
+    prop-types "^15.5.4"
+    warning "^3.0.0"
 
 react@^16.2.0:
   version "16.2.0"
@@ -5107,6 +5150,10 @@ resolve-cwd@^2.0.0:
 resolve-from@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-3.0.0.tgz#b22c7af7d9d6881bc8b6e653335eebcb0a188748"
+
+resolve-pathname@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/resolve-pathname/-/resolve-pathname-2.2.0.tgz#7e9ae21ed815fd63ab189adeee64dc831eefa879"
 
 resolve-url@^0.2.1:
   version "0.2.1"
@@ -5963,6 +6010,10 @@ validate-npm-package-license@^3.0.1:
     spdx-correct "~1.0.0"
     spdx-expression-parse "~1.0.0"
 
+value-equal@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/value-equal/-/value-equal-0.4.0.tgz#c5bdd2f54ee093c04839d71ce2e4758a6890abc7"
+
 vary@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/vary/-/vary-1.1.2.tgz#2299f02c6ded30d4a5961b0b9f74524a18f634fc"
@@ -5988,6 +6039,12 @@ vm-browserify@0.0.4:
   resolved "https://registry.yarnpkg.com/vm-browserify/-/vm-browserify-0.0.4.tgz#5d7ea45bbef9e4a6ff65f95438e0a87c357d5a73"
   dependencies:
     indexof "0.0.1"
+
+warning@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/warning/-/warning-3.0.0.tgz#32e5377cb572de4ab04753bdf8821c01ed605b7c"
+  dependencies:
+    loose-envify "^1.0.0"
 
 watchpack@^1.4.0:
   version "1.4.0"


### PR DESCRIPTION
```
yarn add react-router react-router-dom
```

- added `startup/routes.js`
- added `router/index.js`

## warningについて
```
warning.js:33 Warning: Text content did not match. Server: "sample" Client: "Hello, "
```

reactのバグらしい
[SSR: ReactDOM client and server handling newlines differently causing mismatch warnings · Issue #11103 · facebook/react](https://github.com/facebook/react/issues/11103)

以下で解消された
```
import { renderToString } from 'react-dom/server'

return(renderToString(
  <StaticRouter location={this.props.path} context={{}}>
    {this.props.children}
  </StaticRouter>)
)
      
```

## 参考
- [react-router v4 with Webpacker & SSR · Issue #843 · reactjs/react-rails](https://github.com/reactjs/react-rails/issues/843)
- [React Router · React On Rails](https://shakacode.gitbooks.io/react-on-rails/content/docs/additional-reading/react-router.html)